### PR TITLE
use new directory format to download unstable builds

### DIFF
--- a/src/org/radare/installer/MainActivity.java
+++ b/src/org/radare/installer/MainActivity.java
@@ -83,7 +83,7 @@ public class MainActivity extends Activity {
 
 					if (checkHg.isChecked()) {
 						output("Download: unstable/development version from nightly build.\nNote: this version can be broken!\n");
-						hg = "hg";
+						hg = "unstable";
 					} else {
 						output("Download: stable version\n");
 						hg = "stable";


### PR DESCRIPTION
Here's a little change i did in the server. as long as we are not using 'hg' anymore the application should find the updates in a path without specifying any version control system. so i changed the name to "unstable".

I have also uploaded new builds from the latest git commit for android-arm,x86,mips.

Thanks!
